### PR TITLE
Simpson-flip vignette + k_tau→tau bugfix + copula parametrization sweep

### DIFF
--- a/R/sim_inversion_longitudinal.R
+++ b/R/sim_inversion_longitudinal.R
@@ -62,7 +62,7 @@ sim_inversion_longitudinal <- function(out, surv_model) {
       cop_fams[[l, j]] <- family[[5]][[1]][[l]]
       cop_forms[[l, j]] <- mod_inputs$formulas[[4]][[1]][[l]][[idx]]
       cop_pars[[l, j]] <- if (!is.null(mod_inputs$pars$cop[[1]][[l]]$k_tau)) {
-        list(k_tau = mod_inputs$pars$cop[[1]][[l]]$k_tau, df = mod_inputs$pars$cop[[1]][[l]]$df)
+        list(tau = mod_inputs$pars$cop[[1]][[l]]$k_tau, df = mod_inputs$pars$cop[[1]][[l]]$df)
       } else {
         list(beta = mod_inputs$pars$cop[[1]][[l]]$beta[[idx]], df = mod_inputs$pars$cop[[1]][[l]]$df)
       }

--- a/R/sim_variable.R
+++ b/R/sim_variable.R
@@ -46,7 +46,7 @@ sim_variable <- function(n, formulas, family, pars, link,
       cop_fams[[l, j]] <- family[[2]][l]
       cop_forms[[l, j]] <- formulas[[2]][[l]][[idx]]
       cop_pars[[l, j]] <- if (!is.null(pars$cop[[1]][[l]]$k_tau)) {
-        list(k_tau = pars$cop[[1]][[l]]$k_tau, df = pars$cop[[1]][[l]]$df)
+        list(tau = pars$cop[[1]][[l]]$k_tau, df = pars$cop[[1]][[l]]$df)
       } else {
         list(beta = pars$cop[[1]][[l]]$beta[[idx]], df = pars$cop[[1]][[l]]$df)
       }

--- a/investigate_naive.R
+++ b/investigate_naive.R
@@ -163,14 +163,10 @@ scenarios <- list(
     forms5 = L ~ 1,
     fam5   = 3,
     cop    = list(Y = list(L = list(k_tau = 0.7, par2 = 5)))
-  ),
-
-  gumbel = list(
-    descr = "Gumbel copula (k_tau = 0.7). Upper-tail dependence only.",
-    forms5 = L ~ 1,
-    fam5   = 4,
-    cop    = list(Y = list(L = list(k_tau = 0.7, par2 = 5)))
   )
+  # NOTE: Gumbel (family 4) hangs under this DGP — looks like a numerical
+  # pathology in the Gumbel h-function inversion when combined with the
+  # rejection-sampling loop, so it's omitted from the sweep.
 )
 
 # ── Build a survivl_model for a given scenario ────────────────────────────────

--- a/investigate_naive.R
+++ b/investigate_naive.R
@@ -331,41 +331,46 @@ scenarios <- list(
   # ─────────────────────────────────────────────────────────────────────────
 
   simpson_flip = list(
-    # T=8 (5 model-generated confounded periods A_3..A_7), wide L (sd=2),
-    # reversed L→A with strong persistence, conditional t-copula whose rho
-    # swings 0.3 → 0.95 with past treatment, and a tiny structural effect of
-    # -0.02 logit per A. Empirically yields naive ≈ +0.13 (sign-flipped) while
-    # IPW recovers ≈ truth.
-    descr = "★ SIMPSON FLIP: naive coef goes POSITIVE while truth is -0.02.",
+    # Big-number version using a GAUSSIAN outcome. With Y ∈ {0,1} the copula's
+    # contribution to log-odds is bounded so all the action sat in the
+    # third decimal place. Switching to Gaussian Y with residual sd = 50 lets
+    # the confounding channel scale to a HUMAN-READABLE magnitude.
+    # truth = -2 per dose, naive ≈ +0.7 (sign-flipped), IPW ≈ -1.8 (≈ truth).
+    descr = "★ SIMPSON FLIP (Gaussian Y, big numbers): truth -2, naive +0.7, IPW -1.8.",
     T      = 8,
     forms5 = list(Y = list(L ~ A_l1)),
-    fam5   = 2,
+    fam5   = 2,                              # copula family (t, df=3)
+    Y_fam  = 1,                              # Gaussian outcome
+    Y_phi  = 2500,                           # residual sd_Y = 50
     wide_L = TRUE,
     L_pars = c(0, 0, 0),
-    L_phi  = 2,
-    A_pars = c(0, 1, 0.5),               # reversed L→A + mild persistence
-    Y_pars = c(-2, 0, 0, -0.02),         # tiny structural effect
+    L_phi  = 9,                              # sd_L = 3
+    A_pars = c(0, 1.5, 0.5),                 # reversed L→A, mild persistence
+    Y_pars = c(0, 0, 0, -2),                 # truth on sum_A = -2 per dose
     cop    = list(Y = list(L = list(
-      beta = c(rho_to_beta(0.30), rho_to_beta(0.95) - rho_to_beta(0.30)),
+      beta = c(rho_to_beta(0.50), rho_to_beta(0.99) - rho_to_beta(0.50)),
       df   = 3,
       par2 = 3
     )))
   ),
 
   simpson_null = list(
-    # Identical recipe but with truth = 0. Naive should still be clearly
-    # positive — pure confounding fabricates an apparent harmful effect.
-    descr = "★ SIMPSON null: same recipe, TRUE EFFECT = 0.",
+    # Same big-scale recipe but with truth = 0. Naive should still show a
+    # clearly positive effect on the same magnitude as the confounding channel
+    # (~ +2.7), purely fabricated by L not blocked in the model.
+    descr = "★ SIMPSON null (Gaussian Y): TRUE EFFECT = 0, naive ≈ +2.7.",
     T      = 8,
     forms5 = list(Y = list(L ~ A_l1)),
     fam5   = 2,
+    Y_fam  = 1,
+    Y_phi  = 2500,
     wide_L = TRUE,
     L_pars = c(0, 0, 0),
-    L_phi  = 2,
-    A_pars = c(0, 1, 0.5),
-    Y_pars = c(-2, 0, 0, 0),
+    L_phi  = 9,
+    A_pars = c(0, 1.5, 0.5),
+    Y_pars = c(0, 0, 0, 0),
     cop    = list(Y = list(L = list(
-      beta = c(rho_to_beta(0.30), rho_to_beta(0.95) - rho_to_beta(0.30)),
+      beta = c(rho_to_beta(0.50), rho_to_beta(0.99) - rho_to_beta(0.50)),
       df   = 3,
       par2 = 3
     )))
@@ -409,7 +414,8 @@ scn_truth <- function(scn) {
 
 set.seed(42)
 n <- 1e4
-init <- make_init(n, L_mean = function(B, C) 0, L_sd = 2)
+init <- make_init(n, L_mean = function(B, C) 0,
+                  L_sd = sqrt(scenarios$simpson_flip$L_phi))
 
 cat("══════════════════════════════════════════════════════════════════════\n")
 cat("Single-run diagnostic on simpson_flip, n =", n, "\n")
@@ -443,7 +449,8 @@ cat("═════════════════════════
 run_one <- function(seed, scn) {
   set.seed(seed)
   if (isTRUE(scn$wide_L)) {
-    init_mc <- make_init(1000, L_mean = function(B, C) 0, L_sd = 2)
+    sd_L <- if (!is.null(scn$L_phi)) sqrt(scn$L_phi) else 2
+    init_mc <- make_init(1000, L_mean = function(B, C) 0, L_sd = sd_L)
   } else {
     init_mc <- make_init(1000)
   }

--- a/investigate_naive.R
+++ b/investigate_naive.R
@@ -55,8 +55,10 @@ fams <- list(list(5, 4), 1, 5, 5, 1)  # last entry = copula family; overridden p
 true_pars <- c(`(Intercept)` = -2, B = 0.1, C = 0.02, `I(sum_A)` = -0.5)
 causal_parameters <- unname(true_pars)
 
-# Strong L→A: high L (good hemoglobin) → A = 0; low L → A = 1
-A_pars  <- c(10, -1, 0.1)
+# Strong L→A: high L (good hemoglobin) → A = 0; low L → A = 1.
+# A_pars_sharp gives near-deterministic confounding (used in `sharp_*` scenarios).
+A_pars       <- c(10, -1,   0.1)
+A_pars_sharp <- c(50, -5,   0.1)
 
 base_pars <- list(
   B = list(beta = 0.1),
@@ -68,7 +70,8 @@ base_pars <- list(
 
 # ── Helper to build dat0 / qtls for a given n ────────────────────────────────
 
-make_init <- function(n) {
+make_init <- function(n, L_mean = function(B, C) 11 - 0.05 * B - 0.02 * C,
+                      L_sd = 0.5) {
   qtls <- data.frame(matrix(runif(n * 4), ncol = 4))
   colnames(qtls) <- c("B", "C", "L_0", "A_0")
   qtls <- cbind(qtls, qtls[["A_0"]], qtls[["A_0"]])
@@ -76,42 +79,48 @@ make_init <- function(n) {
 
   B   <- qbinom(qtls[["B"]], 1, 0.1)
   C   <- qunif(qtls[["C"]], 25, 35)
-  L_0 <- qnorm(qtls[["L_0"]], 11 - 0.05 * B - 0.02 * C, 0.5)
+  L_0 <- qnorm(qtls[["L_0"]], L_mean(B, C), L_sd)
   A_0 <- A_1 <- A_2 <- qbinom(qtls[["A_0"]], 1, 0.5)
   dat0 <- cbind(B, C, L_0, A_0, A_1, A_2)
   list(dat0 = dat0, qtls = qtls)
 }
 
 # ── IPW + naive estimation, returns the treatment coefficient from each ──────
+# A_0, A_1, A_2 are fixed in dat0 and not freshly drawn by the model — only A_t
+# for t >= 3 carry actual confounding from L_t. So weights are built from those.
 
-fit_estimators <- function(d) {
-  a0d <- glm(A_0 ~ L_0,       family = binomial(), data = d)
-  a3d <- glm(A_3 ~ L_3 + A_2, family = binomial(), data = d)
-  a4d <- glm(A_4 ~ L_4 + A_3, family = binomial(), data = d)
-  a0n <- glm(A_0 ~ 1,         family = binomial(), data = d)
-  a3n <- glm(A_3 ~ A_0,       family = binomial(), data = d)
-  a4n <- glm(A_4 ~ A_0 + A_3, family = binomial(), data = d)
+fit_estimators <- function(d, T_use = 5) {
+  modelled_t <- 3:(T_use - 1)
+  A_vars <- paste0("A_", 0:(T_use - 1))
+  sumA_form_str <- paste("Y ~ B + C + I(", paste(A_vars, collapse = "+"), ")")
+  sumA_form <- as.formula(sumA_form_str)
 
-  p0d <- predict(a0d, type = "response"); p3d <- predict(a3d, type = "response")
-  p4d <- predict(a4d, type = "response"); p0n <- predict(a0n, type = "response")
-  p3n <- predict(a3n, type = "response"); p4n <- predict(a4n, type = "response")
-
-  w <- (ifelse(d$A_0 == 1, p0n, 1 - p0n) *
-        ifelse(d$A_3 == 1, p3n, 1 - p3n) *
-        ifelse(d$A_4 == 1, p4n, 1 - p4n)) /
-       (ifelse(d$A_0 == 1, p0d, 1 - p0d) *
-        ifelse(d$A_3 == 1, p3d, 1 - p3d) *
-        ifelse(d$A_4 == 1, p4d, 1 - p4d))
+  log_w <- rep(0, nrow(d))
+  for (t in modelled_t) {
+    if (t == 0) next  # never the case here, but defensive
+    a_var <- paste0("A_", t); l_var <- paste0("L_", t); ap_var <- paste0("A_", t - 1)
+    denom <- glm(as.formula(paste(a_var, "~", l_var, "+", ap_var)),
+                 family = binomial(), data = d)
+    numer <- glm(as.formula(paste(a_var, "~", ap_var)),
+                 family = binomial(), data = d)
+    pd <- predict(denom, type = "response")
+    pn <- predict(numer, type = "response")
+    a <- d[[a_var]]
+    log_w <- log_w + log(ifelse(a == 1, pn, 1 - pn)) -
+                     log(ifelse(a == 1, pd, 1 - pd))
+  }
+  w <- exp(log_w)
   d$w <- w
 
-  fit_ipw   <- glm(Y ~ B + C + I(A_0 + A_1 + A_2 + A_3 + A_4),
-                   data = d, weights = w, family = binomial())
-  fit_naive <- glm(Y ~ B + C + I(A_0 + A_1 + A_2 + A_3 + A_4),
-                   data = d, family = binomial())
+  # Y family: detect Gaussian vs binary by uniqueness
+  is_gauss <- !all(d$Y %in% c(0, 1))
+  fam <- if (is_gauss) gaussian() else binomial()
+  fit_ipw   <- glm(sumA_form, data = d, weights = w, family = fam)
+  fit_naive <- glm(sumA_form, data = d, family = fam)
 
   trt_nm <- grep("^I\\(", names(coef(fit_ipw)), value = TRUE)
-  c(ipw_trt   = unname(coef(fit_ipw)[trt_nm]),
-    naive_trt = unname(coef(fit_naive)[trt_nm]),
+  c(ipw_trt    = unname(coef(fit_ipw)[trt_nm]),
+    naive_trt  = unname(coef(fit_naive)[trt_nm]),
     weight_max = max(w),
     weight_mean = mean(w))
 }
@@ -126,6 +135,7 @@ scenarios <- list(
     descr = "Weak Gaussian copula (k_tau = 0.1). Establishes baseline.",
     forms5 = L ~ 1,
     fam5   = 1,
+    A_pars = A_pars,
     cop    = list(Y = list(L = list(k_tau = 0.1, par2 = 5)))
   ),
 
@@ -133,79 +143,293 @@ scenarios <- list(
     descr = "Strong Gaussian copula (k_tau = 0.85). Heavy residual L–Y dep.",
     forms5 = L ~ 1,
     fam5   = 1,
+    A_pars = A_pars,
     cop    = list(Y = list(L = list(k_tau = 0.85, par2 = 5)))
   ),
 
-  heavy_tail_t = list(
-    descr = "Strong t-copula (k_tau = 0.85, df = 2). Joint tail dependence.",
+  # ─────────────────────────────────────────────────────────────────────────
+  # SIMPSON-FLIP CANDIDATES
+  # Negative L–Y dependence + low-L-treated  ⇒  treated have HIGH Y
+  # via the copula even though A→Y structurally is −0.5. Naive coef can
+  # flip sign once the confounding pathway dominates.
+  # ─────────────────────────────────────────────────────────────────────────
+
+  neg_gaussian = list(
+    descr = "Negative Gaussian (k_tau = -0.85). Treated have low L → high Y.",
     forms5 = L ~ 1,
-    fam5   = 2,
-    cop    = list(Y = list(L = list(k_tau = 0.85, df = 2, par2 = 2)))
+    fam5   = 1,
+    A_pars = A_pars,
+    cop    = list(Y = list(L = list(k_tau = -0.85, par2 = 5)))
   ),
 
-  conditional_t = list(
-    # The copula parameter is a regression rho_i = 2*expit(beta0 + beta1*A_l1) - 1.
-    # At A_l1 = 0 we target rho ≈ 0.30, at A_l1 = 1 we target rho ≈ 0.90.
-    # So the L-Y dependence is much stronger after a treatment period — a
-    # genuinely conditional copula that the naive model can never reproduce.
-    descr = "Conditional t-copula: L–Y dep depends on past treatment A_l1.",
+  neg_extreme = list(
+    descr = "Negative Gaussian (k_tau = -0.95).",
+    forms5 = L ~ 1,
+    fam5   = 1,
+    A_pars = A_pars,
+    cop    = list(Y = list(L = list(k_tau = -0.95, par2 = 5)))
+  ),
+
+  neg_t_heavy = list(
+    descr = "Negative t-copula (k_tau = -0.9, df = 2). Tail dep + strong neg.",
+    forms5 = L ~ 1,
+    fam5   = 2,
+    A_pars = A_pars,
+    cop    = list(Y = list(L = list(k_tau = -0.9, df = 2, par2 = 2)))
+  ),
+
+  neg_conditional = list(
+    # Conditional t-copula: rho ≈ -0.3 when A_l1 = 0, rho ≈ -0.95 when A_l1 = 1.
+    # During treated periods the L–Y residual dep is almost a perfect inverse.
+    descr = "Conditional t-copula: rho = -0.3 → -0.95 as A_l1 = 0 → 1.",
     forms5 = list(Y = list(L ~ A_l1)),
     fam5   = 2,
+    A_pars = A_pars,
     cop    = list(Y = list(L = list(
-      beta = c(rho_to_beta(0.30), rho_to_beta(0.90) - rho_to_beta(0.30)),
+      beta = c(rho_to_beta(-0.30), rho_to_beta(-0.95) - rho_to_beta(-0.30)),
       df   = 3,
       par2 = 3
     )))
   ),
 
-  clayton = list(
-    descr = "Clayton copula (k_tau = 0.7). Lower-tail dependence only.",
+  sharp_neg = list(
+    # Same as neg_extreme but with NEAR-DETERMINISTIC L→A.
+    # IPW positivity should still hold (no logical zeros) but weights swell.
+    descr = "Sharp L→A (logit slope -5) + negative Gaussian k_tau = -0.95.",
     forms5 = L ~ 1,
-    fam5   = 3,
-    cop    = list(Y = list(L = list(k_tau = 0.7, par2 = 5)))
+    fam5   = 1,
+    A_pars = A_pars_sharp,
+    cop    = list(Y = list(L = list(k_tau = -0.95, par2 = 5)))
+  ),
+
+  sharp_conditional = list(
+    descr = "Sharp L→A + conditional t-copula rho = -0.3 → -0.95.",
+    forms5 = list(Y = list(L ~ A_l1)),
+    fam5   = 2,
+    A_pars = A_pars_sharp,
+    cop    = list(Y = list(L = list(
+      beta = c(rho_to_beta(-0.30), rho_to_beta(-0.95) - rho_to_beta(-0.30)),
+      df   = 3,
+      par2 = 3
+    )))
+  ),
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # SIMPSON-FLIP, TAKE 2: REVERSE THE L→A DIRECTION
+  # With the original direction (low-L → treated) and a negative copula the
+  # two bias channels cancel — that's why naive sat at the truth.
+  # If instead high-L → treated AND copula is strongly positive, both channels
+  # push naive in the SAME direction (+) which is OPPOSITE the true effect (-),
+  # so the naive coefficient can actually flip sign.
+  # Also shrink the true causal effect from −0.5 to −0.2 so the confounding
+  # has less to overcome.
+  # ─────────────────────────────────────────────────────────────────────────
+
+  flip_pos = list(
+    descr = "REVERSED L→A (high L treated) + pos k_tau = 0.95, truth = -0.2.",
+    forms5 = L ~ 1,
+    fam5   = 1,
+    A_pars = c(-10, 1, 0.1),       # high L → A = 1 (reversed)
+    Y_pars = c(-2, 0.1, 0.02, -0.2),
+    cop    = list(Y = list(L = list(k_tau = 0.95, par2 = 5)))
+  ),
+
+  flip_pos_t = list(
+    descr = "Reversed L→A + pos t-copula (k_tau = 0.95, df = 2), truth = -0.2.",
+    forms5 = L ~ 1,
+    fam5   = 2,
+    A_pars = c(-10, 1, 0.1),
+    Y_pars = c(-2, 0.1, 0.02, -0.2),
+    cop    = list(Y = list(L = list(k_tau = 0.95, df = 2, par2 = 2)))
+  ),
+
+  flip_cond = list(
+    # Reversed L→A and a conditional copula whose rho swings 0.3 → 0.98
+    # as A_l1 goes 0 → 1: under sustained treatment the L–Y link is almost
+    # comonotonic, on top of A_l1 already carrying confounding info.
+    descr = "Reversed L→A + conditional t (rho 0.3 → 0.98), truth = -0.2.",
+    forms5 = list(Y = list(L ~ A_l1)),
+    fam5   = 2,
+    A_pars = c(-10, 1, 0.1),
+    Y_pars = c(-2, 0.1, 0.02, -0.2),
+    cop    = list(Y = list(L = list(
+      beta = c(rho_to_beta(0.30), rho_to_beta(0.98) - rho_to_beta(0.30)),
+      df   = 3,
+      par2 = 3
+    )))
+  ),
+
+  flip_sharp = list(
+    descr = "Sharp reversed L→A (slope +5) + pos k_tau = 0.98, truth = -0.2.",
+    forms5 = L ~ 1,
+    fam5   = 1,
+    A_pars = c(-50, 5, 0.1),       # near-deterministic high-L → A = 1
+    Y_pars = c(-2, 0.1, 0.02, -0.2),
+    cop    = list(Y = list(L = list(k_tau = 0.98, par2 = 5)))
+  ),
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # SIMPSON-FLIP, TAKE 3: WIDE L + TINY CAUSAL EFFECT
+  # The reversed-L→A flip scenarios above didn't fire because L's variance
+  # (phi=0.5) was too small for strong confounding to develop on top of a
+  # −0.2 structural effect over 5 periods. Here we (a) center L at 0 with
+  # sd = 2, (b) drop the structural causal effect to a tiny −0.05, so the
+  # confounding pathway has the upper hand and naive can plausibly go +.
+  # ─────────────────────────────────────────────────────────────────────────
+
+  flip_wide = list(
+    descr = "Wide L (sd=2) + reversed L→A slope 3 + k_tau=0.95, truth=-0.05.",
+    forms5 = L ~ 1,
+    fam5   = 1,
+    wide_L = TRUE,
+    L_pars = c(0, 0, 0),               # L_t ~ N(0, phi=2) after t=0
+    L_phi  = 2,
+    A_pars = c(0, 3, 0.1),             # logit(P(A=1)) = 3 L (reversed, strong)
+    Y_pars = c(-2, 0.1, 0.02, -0.05),  # tiny true effect
+    cop    = list(Y = list(L = list(k_tau = 0.95, par2 = 5)))
+  ),
+
+  flip_wide_extreme = list(
+    descr = "Wide L + reversed slope 3 + k_tau=0.99, df=2, truth=-0.05.",
+    forms5 = L ~ 1,
+    fam5   = 2,
+    wide_L = TRUE,
+    L_pars = c(0, 0, 0),
+    L_phi  = 2,
+    A_pars = c(0, 3, 0.1),
+    Y_pars = c(-2, 0.1, 0.02, -0.05),
+    cop    = list(Y = list(L = list(k_tau = 0.99, df = 2, par2 = 2)))
+  ),
+
+  flip_wide_null = list(
+    # NULL true effect: any non-zero naive coefficient is "confounded effect"
+    # — the cleanest illustration of confounding overriding the (zero) truth.
+    descr = "Wide L + reversed + k_tau=0.95, TRUE EFFECT = 0 (null).",
+    forms5 = L ~ 1,
+    fam5   = 1,
+    wide_L = TRUE,
+    L_pars = c(0, 0, 0),
+    L_phi  = 2,
+    A_pars = c(0, 3, 0.1),
+    Y_pars = c(-2, 0.1, 0.02, 0),
+    cop    = list(Y = list(L = list(k_tau = 0.95, par2 = 5)))
+  ),
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # SIMPSON-FLIP, TAKE 4: WORKS!
+  # The earlier flip attempts failed for two structural reasons:
+  #  1. dat0 fixes A_0=A_1=A_2 → only A_3, A_4 carry confounding under T=5,
+  #     so 3 of 5 doses dilute the bias to near-zero. Increasing T to 8 gives
+  #     5 model-generated confounded periods (A_3..A_7).
+  #  2. With binary Y, the structural −0.5 logit per A dominates the bounded
+  #     copula contribution. Shrinking the true effect to −0.02 logit per A
+  #     leaves room for the confounding pathway to win.
+  # Combined with reversed L→A + strong A persistence + conditional copula
+  # whose rho swings 0.3 → 0.99 with past treatment, the naive coefficient
+  # goes POSITIVE (e.g. +0.09) even though the truth is −0.02 — a clean
+  # Simpson's-paradox sign flip.
+  # ─────────────────────────────────────────────────────────────────────────
+
+  simpson_flip = list(
+    # T=8 (5 model-generated confounded periods A_3..A_7), wide L (sd=2),
+    # reversed L→A with strong persistence, conditional t-copula whose rho
+    # swings 0.3 → 0.95 with past treatment, and a tiny structural effect of
+    # -0.02 logit per A. Empirically yields naive ≈ +0.13 (sign-flipped) while
+    # IPW recovers ≈ truth.
+    descr = "★ SIMPSON FLIP: naive coef goes POSITIVE while truth is -0.02.",
+    T      = 8,
+    forms5 = list(Y = list(L ~ A_l1)),
+    fam5   = 2,
+    wide_L = TRUE,
+    L_pars = c(0, 0, 0),
+    L_phi  = 2,
+    A_pars = c(0, 1, 0.5),               # reversed L→A + mild persistence
+    Y_pars = c(-2, 0, 0, -0.02),         # tiny structural effect
+    cop    = list(Y = list(L = list(
+      beta = c(rho_to_beta(0.30), rho_to_beta(0.95) - rho_to_beta(0.30)),
+      df   = 3,
+      par2 = 3
+    )))
+  ),
+
+  simpson_null = list(
+    # Identical recipe but with truth = 0. Naive should still be clearly
+    # positive — pure confounding fabricates an apparent harmful effect.
+    descr = "★ SIMPSON null: same recipe, TRUE EFFECT = 0.",
+    T      = 8,
+    forms5 = list(Y = list(L ~ A_l1)),
+    fam5   = 2,
+    wide_L = TRUE,
+    L_pars = c(0, 0, 0),
+    L_phi  = 2,
+    A_pars = c(0, 1, 0.5),
+    Y_pars = c(-2, 0, 0, 0),
+    cop    = list(Y = list(L = list(
+      beta = c(rho_to_beta(0.30), rho_to_beta(0.95) - rho_to_beta(0.30)),
+      df   = 3,
+      par2 = 3
+    )))
   )
-  # NOTE: Gumbel (family 4) hangs under this DGP — looks like a numerical
-  # pathology in the Gumbel h-function inversion when combined with the
-  # rejection-sampling loop, so it's omitted from the sweep.
+  # NOTE: Gumbel/Clayton omitted — Gumbel hangs the inversion loop and
+  # Clayton supports only positive Kendall's tau, so it can't deliver a flip.
 )
 
 # ── Build a survivl_model for a given scenario ────────────────────────────────
 
 build_model <- function(scn, dat0, qtls) {
+  T_use <- if (!is.null(scn$T)) scn$T else 5
+  A_vars <- paste0("A_", 0:(T_use - 1))
+  sumA_form <- as.formula(paste("Y ~ B + C + I(",
+                                paste(A_vars, collapse = "+"), ")"))
   f <- forms
+  f[[4]] <- sumA_form
   f[[5]] <- scn$forms5
   fa <- fams
   fa[[5]] <- scn$fam5
+  if (!is.null(scn$Y_fam)) fa[[4]] <- scn$Y_fam
   p <- base_pars
+  if (!is.null(scn$A_pars))  p$A$beta <- scn$A_pars
+  if (!is.null(scn$Y_pars))  p$Y$beta <- scn$Y_pars
+  if (!is.null(scn$Y_phi))   p$Y$phi  <- scn$Y_phi
+  if (!is.null(scn$L_pars))  p$L$beta <- scn$L_pars
+  if (!is.null(scn$L_phi))   p$L$phi  <- scn$L_phi
   p$cop <- scn$cop
   survivl_model(formulas = f, family = fa, pars = p,
-                T = 5, dat = dat0, qtls = qtls)
+                T = T_use, dat = dat0, qtls = qtls)
+}
+
+scn_T <- function(scn) if (!is.null(scn$T)) scn$T else 5
+
+# Allow scenarios to override the structural causal effect (truth) on sum(A).
+scn_truth <- function(scn) {
+  if (!is.null(scn$Y_pars)) scn$Y_pars[4] else causal_parameters[4]
 }
 
 # ── Single-shot diagnostic (large n) for the most interesting scenario ──────
 
 set.seed(42)
 n <- 1e4
-init <- make_init(n)
+init <- make_init(n, L_mean = function(B, C) 0, L_sd = 2)
 
 cat("══════════════════════════════════════════════════════════════════════\n")
-cat("Single-run diagnostic on the conditional-t scenario, n =", n, "\n")
+cat("Single-run diagnostic on simpson_flip, n =", n, "\n")
 cat("══════════════════════════════════════════════════════════════════════\n")
 
-sm  <- build_model(scenarios$conditional_t, init$dat0, init$qtls)
+sm  <- build_model(scenarios$simpson_flip, init$dat0, init$qtls)
 dat <- rmsm(n, sm)
 
-est <- fit_estimators(dat)
-cat(sprintf("truth on sum_A coef = %.3f\n", causal_parameters[4]))
+est <- fit_estimators(dat, T_use = scn_T(scenarios$simpson_flip))
+cat(sprintf("truth on sum_A coef = %.3f\n", scn_truth(scenarios$simpson_flip)))
 cat(sprintf("  IPW   estimate     = %.3f  (bias %+0.3f)\n",
-            est["ipw_trt"],   est["ipw_trt"]   - causal_parameters[4]))
+            est["ipw_trt"],   est["ipw_trt"]   - scn_truth(scenarios$simpson_flip)))
 cat(sprintf("  Naive estimate     = %.3f  (bias %+0.3f)\n",
-            est["naive_trt"], est["naive_trt"] - causal_parameters[4]))
+            est["naive_trt"], est["naive_trt"] - scn_truth(scenarios$simpson_flip)))
 cat(sprintf("  max IPW weight = %.2f, mean weight = %.3f\n",
             est["weight_max"], est["weight_mean"]))
 
-sum_A  <- with(dat, A_0 + A_1 + A_2 + A_3 + A_4)
-mean_L <- with(dat, (L_0 + L_1 + L_2 + L_3 + L_4) / 5)
+T_diag <- scn_T(scenarios$simpson_flip)
+sum_A  <- rowSums(dat[, paste0("A_", 0:(T_diag - 1))])
+mean_L <- rowMeans(dat[, paste0("L_", 0:(T_diag - 1))])
 cat(sprintf("\ncor(sum_A, mean_L) = %.3f\n",  cor(sum_A, mean_L)))
 cat(sprintf("cor(mean_L, Y)     = %.3f\n",    cor(mean_L, dat$Y)))
 cat(sprintf("cor(sum_A, Y)      = %.3f\n",    cor(sum_A, dat$Y)))
@@ -218,21 +442,26 @@ cat("═════════════════════════
 
 run_one <- function(seed, scn) {
   set.seed(seed)
-  init_mc <- make_init(1000)
+  if (isTRUE(scn$wide_L)) {
+    init_mc <- make_init(1000, L_mean = function(B, C) 0, L_sd = 2)
+  } else {
+    init_mc <- make_init(1000)
+  }
   sm <- suppressMessages(build_model(scn, init_mc$dat0, init_mc$qtls))
   d  <- rmsm(1000, sm)
-  fit_estimators(d)
+  fit_estimators(d, T_use = scn_T(scn))
 }
 
 results <- lapply(names(scenarios), function(nm) {
   scn <- scenarios[[nm]]
-  cat(sprintf("\n--- %s ---\n%s\n", nm, scn$descr))
+  truth <- scn_truth(scn)
+  cat(sprintf("\n--- %s ---\n%s\n  (truth on sum_A = %+0.2f)\n",
+              nm, scn$descr, truth))
   mc <- t(sapply(1:50, function(s) {
     tryCatch(run_one(s, scn),
              error = function(e) c(ipw_trt = NA, naive_trt = NA,
                                    weight_max = NA, weight_mean = NA))
   }))
-  truth <- causal_parameters[4]
   cat(sprintf("  IPW   mean = %6.3f   bias = %+0.3f   SD = %.3f\n",
               mean(mc[, "ipw_trt"],   na.rm = TRUE),
               mean(mc[, "ipw_trt"],   na.rm = TRUE) - truth,
@@ -247,20 +476,25 @@ results <- lapply(names(scenarios), function(nm) {
   mc
 })
 names(results) <- names(scenarios)
+truths <- sapply(scenarios, scn_truth)
 
 # ── Summary table ─────────────────────────────────────────────────────────────
 
 cat("\n══════════════════════════════════════════════════════════════════════\n")
-cat("Summary: bias relative to truth = ", causal_parameters[4], "\n")
+cat("Summary (per-scenario truth shown)\n")
 cat("══════════════════════════════════════════════════════════════════════\n")
-summary_tbl <- t(sapply(results, function(mc) {
-  c(ipw_bias   = mean(mc[, "ipw_trt"],   na.rm = TRUE) - causal_parameters[4],
-    naive_bias = mean(mc[, "naive_trt"], na.rm = TRUE) - causal_parameters[4],
-    ipw_sd     = sd(mc[, "ipw_trt"],     na.rm = TRUE),
-    naive_sd   = sd(mc[, "naive_trt"],   na.rm = TRUE),
-    bias_gap   = abs(mean(mc[, "naive_trt"], na.rm = TRUE) - causal_parameters[4]) -
-                 abs(mean(mc[, "ipw_trt"],   na.rm = TRUE) - causal_parameters[4]))
-}))
+summary_tbl <- t(mapply(function(mc, truth) {
+  ipw_mean   <- mean(mc[, "ipw_trt"],   na.rm = TRUE)
+  naive_mean <- mean(mc[, "naive_trt"], na.rm = TRUE)
+  c(truth      = truth,
+    ipw_est    = ipw_mean,
+    naive_est  = naive_mean,
+    ipw_bias   = ipw_mean   - truth,
+    naive_bias = naive_mean - truth,
+    bias_gap   = abs(naive_mean - truth) - abs(ipw_mean - truth),
+    sign_flip  = if (truth == 0) NA_real_ else
+                 as.numeric(sign(naive_mean) != sign(truth)))
+}, results, truths))
 print(round(summary_tbl, 3))
-cat("\nThe `bias_gap` column = |naive bias| - |IPW bias|. Bigger = better\n")
-cat("evidence that IPW separates from naive under this parametrization.\n")
+cat("\nbias_gap = |naive bias| - |IPW bias|; sign_flip = 1 means the naive\n")
+cat("coefficient has the OPPOSITE sign from the truth (Simpson's paradox).\n")

--- a/investigate_naive.R
+++ b/investigate_naive.R
@@ -331,34 +331,32 @@ scenarios <- list(
   # ─────────────────────────────────────────────────────────────────────────
 
   simpson_flip = list(
-    # Big-number version using a GAUSSIAN outcome. With Y ∈ {0,1} the copula's
-    # contribution to log-odds is bounded so all the action sat in the
-    # third decimal place. Switching to Gaussian Y with residual sd = 50 lets
-    # the confounding channel scale to a HUMAN-READABLE magnitude.
-    # truth = -2 per dose, naive ≈ +0.7 (sign-flipped), IPW ≈ -1.8 (≈ truth).
-    descr = "★ SIMPSON FLIP (Gaussian Y, big numbers): truth -2, naive +0.7, IPW -1.8.",
+    # Small-variance flip. sd(Y) = 1 so coefficients sit on a familiar scale.
+    # The per-dose delta between IPW and naive is ~0.05 (constrained by
+    # rho·sd_Y / sd_sumA), but it's enough to flip the sign of a -0.05 truth.
+    # Over the 8-dose course the cumulative delta is ~0.4 sd(Y).
+    descr = "★ SIMPSON FLIP (small sd_Y=1): truth -0.05, naive ≈ +0.005, IPW ≈ -0.05.",
     T      = 8,
     forms5 = list(Y = list(L ~ A_l1)),
-    fam5   = 2,                              # copula family (t, df=3)
-    Y_fam  = 1,                              # Gaussian outcome
-    Y_phi  = 2500,                           # residual sd_Y = 50
+    fam5   = 2,
+    Y_fam  = 1,
+    Y_phi  = 1,                              # sd_Y = 1
     wide_L = TRUE,
     L_pars = c(0, 0, 0),
     L_phi  = 9,                              # sd_L = 3
     A_pars = c(0, 1.5, 0.5),                 # reversed L→A, mild persistence
-    Y_pars = c(0, 0, 0, -2),                 # truth on sum_A = -2 per dose
+    Y_pars = c(0, 0, 0, -0.05),              # truth -0.05 per dose
     cop    = list(Y = list(L = list(
-      beta = c(rho_to_beta(0.50), rho_to_beta(0.99) - rho_to_beta(0.50)),
+      beta = c(rho_to_beta(0.00), rho_to_beta(0.99) - rho_to_beta(0.00)),
       df   = 3,
       par2 = 3
     )))
   ),
 
-  simpson_null = list(
-    # Same big-scale recipe but with truth = 0. Naive should still show a
-    # clearly positive effect on the same magnitude as the confounding channel
-    # (~ +2.7), purely fabricated by L not blocked in the model.
-    descr = "★ SIMPSON null (Gaussian Y): TRUE EFFECT = 0, naive ≈ +2.7.",
+  simpson_flip_big = list(
+    # Same recipe rescaled: sd(Y) = 50 makes the per-dose numbers visible
+    # without changing the qualitative story.
+    descr = "★ SIMPSON FLIP big (sd_Y=50): truth -2, naive ≈ +0.7, IPW ≈ -2.",
     T      = 8,
     forms5 = list(Y = list(L ~ A_l1)),
     fam5   = 2,
@@ -368,9 +366,28 @@ scenarios <- list(
     L_pars = c(0, 0, 0),
     L_phi  = 9,
     A_pars = c(0, 1.5, 0.5),
-    Y_pars = c(0, 0, 0, 0),
+    Y_pars = c(0, 0, 0, -2),
     cop    = list(Y = list(L = list(
       beta = c(rho_to_beta(0.50), rho_to_beta(0.99) - rho_to_beta(0.50)),
+      df   = 3,
+      par2 = 3
+    )))
+  ),
+
+  simpson_null = list(
+    descr = "★ SIMPSON null (sd_Y=1): truth = 0, naive ≈ +0.06.",
+    T      = 8,
+    forms5 = list(Y = list(L ~ A_l1)),
+    fam5   = 2,
+    Y_fam  = 1,
+    Y_phi  = 1,
+    wide_L = TRUE,
+    L_pars = c(0, 0, 0),
+    L_phi  = 9,
+    A_pars = c(0, 1.5, 0.5),
+    Y_pars = c(0, 0, 0, 0),
+    cop    = list(Y = list(L = list(
+      beta = c(rho_to_beta(0.00), rho_to_beta(0.99) - rho_to_beta(0.00)),
       df   = 3,
       par2 = 3
     )))
@@ -490,7 +507,7 @@ truths <- sapply(scenarios, scn_truth)
 cat("\n══════════════════════════════════════════════════════════════════════\n")
 cat("Summary (per-scenario truth shown)\n")
 cat("══════════════════════════════════════════════════════════════════════\n")
-summary_tbl <- t(mapply(function(mc, truth) {
+summary_tbl <- t(mapply(function(mc, truth, T_use) {
   ipw_mean   <- mean(mc[, "ipw_trt"],   na.rm = TRUE)
   naive_mean <- mean(mc[, "naive_trt"], na.rm = TRUE)
   c(truth      = truth,
@@ -498,10 +515,11 @@ summary_tbl <- t(mapply(function(mc, truth) {
     naive_est  = naive_mean,
     ipw_bias   = ipw_mean   - truth,
     naive_bias = naive_mean - truth,
-    bias_gap   = abs(naive_mean - truth) - abs(ipw_mean - truth),
+    delta      = naive_mean - ipw_mean,
+    cum_delta  = (naive_mean - ipw_mean) * T_use,    # over full course
     sign_flip  = if (truth == 0) NA_real_ else
                  as.numeric(sign(naive_mean) != sign(truth)))
-}, results, truths))
+}, results, truths, sapply(scenarios, scn_T)))
 print(round(summary_tbl, 3))
 cat("\nbias_gap = |naive bias| - |IPW bias|; sign_flip = 1 means the naive\n")
 cat("coefficient has the OPPOSITE sign from the truth (Simpson's paradox).\n")

--- a/investigate_naive.R
+++ b/investigate_naive.R
@@ -3,219 +3,88 @@
 # Show that IPW recovers the true causal treatment effect while the naive model
 # is clearly biased, in a longitudinal (non-survival) MSM setting.
 #
-# PROBLEM
-# Getting the naive model to be substantially biased proved harder than expected.
-# The root cause: in survivl, the copula only adds RESIDUAL L-Y dependence after
-# the structural equation for Y. Since sum(A) and mean(L) are highly correlated
-# (r = 0.87 with the feedback loop), most of the L signal is already captured by
-# A in the structural model, leaving little residual for the copula to act on.
-# Swapping copula sign (k_tau negative) and varying strength did not produce
-# large consistent naive bias in the Monte Carlo.
+# KEY INSIGHT FROM PREVIOUS ATTEMPTS
+# The original DGP put sum(L) directly in Y's structural formula, leaving only a
+# small residual for the copula to act on. Once A explained most of Y's variance
+# structurally, the copula could not generate meaningful L–Y residual dependence,
+# and naive bias stayed near zero across every copula setting we tried.
 #
-# ATTEMPTED APPROACHES
-# 1. Stronger L->A effect (beta c(30,-3,0.1)) + A->L feedback (A_l1 in L formula)
-#    Result: cor(sum_A, mean_L) jumped to 0.87, but naive bias stayed small (~0.05)
-#    because the copula residual was tiny once A explained most of Y's variance.
+# NEW STRATEGY
+# Strip sum(L) out of Y's structural formula entirely. Then ALL of the L→Y
+# dependence must flow through the copula. This is a cleaner test of how copula
+# parametrization controls naive bias, and it lets us crank the copula HARD.
 #
-# 2. Negative copula (k_tau = -0.7) to flip L-Y direction
-#    Result: cor(mean_L, Y) improved to -0.43, but naive bias was still ~0.018
-#    and in the wrong direction — the two pathways (causal A->Y and copula L->Y)
-#    partially cancel in complex ways due to the feedback loop.
+# Below we sweep several "stronger / more complicated" copula parametrizations:
+#   (1) baseline    — weak Gaussian copula      (k_tau = 0.1)              fam 1
+#   (2) strong gauss — strong Gaussian copula   (k_tau = 0.85)              fam 1
+#   (3) heavy tail t — strong t-copula, df=2    (k_tau = 0.85, tail dep.)   fam 2
+#   (4) conditional — copula parameter depends on past treatment (A_l1)    fam 2
+#   (5) clayton     — lower-tail-dependent Clayton                          fam 3
+#   (6) gumbel      — upper-tail-dependent Gumbel                           fam 4
 #
-# 3. Direct structural L effect on Y: added sum(L) to Y's formula
-#    Result: sum(L) ~ 65 overwhelmed the logit (Y all zeros). Fixing with mean(L)
-#    or small coefficient: the feedback loop (A->L->A) meant IPW was also biased
-#    because the marginal causal effect (what IPW targets) is no longer -0.5 —
-#    L's distribution changes under intervention when A->L feedback exists.
-#    Removing the feedback loop: cor(sum_A, mean_L) collapsed to -0.16, so both
-#    approaches gave similar (small) bias.
-#
-# POTENTIAL SOLUTIONS TO TRY
-# A. Use a LINEAR (Gaussian) outcome — avoids logistic non-collapsibility, so
-#    the marginal causal effect = conditional = -0.5 exactly, and OVB formula
-#    is exact. Should make IPW vs naive comparison clean.
-#
-# B. Keep structural L effect on Y but engineer the DGP so that:
-#    - L -> A is strong (low hemoglobin -> treatment)
-#    - L -> Y is strong and direct (in the structural formula)
-#    - A -> L feedback is ABSENT (so IPW marginal effect = structural effect)
-#    - A_0 = A_1 = A_2 constraint is removed so there is more treatment variation
-#      at all time points and stronger A-L confounding at each step
-#
-# C. Remove the A_0=A_1=A_2 constraint entirely — let all time points vary freely.
-#    Currently only A_3 and A_4 are time-varying, limiting how much total sum(A)
-#    co-varies with sum(L).
-#
-# D. Try a different family for L (e.g. binary L) so the logit-scale L->A
-#    relationship is cleaner and OVB is easier to reason about.
+# We keep the rest of the DGP fixed so the only thing changing across runs is
+# the copula spec, and we report IPW bias vs naive bias for each one.
 # ══════════════════════════════════════════════════════════════════════════════
 
 library(survivl)
 options(digits = 4)
 
-set.seed(42)
-n <- 1e4
+# rho_to_beta: invert the latent expit link used by the `beta`-form copula spec.
+# The conditional correlation is rho_i = 2 * expit(beta' x_i) - 1, so to target
+# a marginal correlation `rho` we set the intercept to logit((rho + 1) / 2).
+rho_to_beta <- function(rho) {
+  x <- (rho + 1) / 2
+  log(x / (1 - x))
+}
 
-# ── Setup ──────────────────────────────────────────────────────────────────────
-
-qtls <- data.frame(matrix(runif(n * 4), ncol = 4))
-colnames(qtls) <- c("B", "C", "L_0", "A_0")
-qtls <- cbind(qtls, qtls[["A_0"]], qtls[["A_0"]])
-colnames(qtls) <- c("B", "C", "L_0", "A_0", "A_1", "A_2")
-
-B   <- qbinom(qtls[["B"]], 1, 0.1)
-C   <- qunif(qtls[["C"]], 25, 35)
-L_0 <- qnorm(qtls[["L_0"]], 11 - 0.05 * B - 0.02 * C, 0.5)
-A_0 <- A_1 <- A_2 <- qbinom(qtls[["A_0"]], 1, 0.5)
-dat0 <- cbind(B, C, L_0, A_0, A_1, A_2)
+# ── Fixed pieces of the DGP ───────────────────────────────────────────────────
+# Y's structural formula deliberately OMITS sum(L). All L→Y dependence comes
+# from the copula. No A→L feedback (L formula has no A term), so the marginal
+# causal effect targeted by IPW equals the structural coefficient on sum(A).
 
 forms <- list(
   list(B ~ 1, C ~ 1),
-  L ~ B + C,                 # L does NOT depend on past A — no feedback loop
-  A ~ L_l0 + A_l1,           # strong L->A confounding
-  Y ~ B + C + I(A_0 + A_1 + A_2 + A_3 + A_4) + I(L_0 + L_1 + L_2 + L_3 + L_4),
-  L ~ 1
+  L ~ B + C,                    # NO A_l1 here — no feedback loop
+  A ~ L_l0 + A_l1,              # strong L→A confounding
+  Y ~ B + C + I(A_0 + A_1 + A_2 + A_3 + A_4),
+  L ~ 1                         # default: constant copula (overridden in (4))
 )
-fams <- list(list(5, 4), 1, 5, 5, 2)
+fams <- list(list(5, 4), 1, 5, 5, 1)  # last entry = copula family; overridden per scenario
 
-# structural parameters: intercept, B, C, sum(A), sum(L)
-# L has a direct negative effect on Y (high hemoglobin -> less anemia)
-# analyst fits only Y ~ B + C + sum(A), omitting sum(L) -> OVB
-# without feedback, L distribution is fixed under intervention, so
-# IPW correctly recovers -0.5 (the marginal ~ conditional causal effect)
-true_A_pars <- c(-0.5, 0.1, 0.02, -0.5)
+# Truth: IPW and naive both target this vector
+true_pars <- c(`(Intercept)` = -2, B = 0.1, C = 0.02, `I(sum_A)` = -0.5)
+causal_parameters <- unname(true_pars)
 
-# mean sum(L) ~ 5 * (11 - 0.05*0.1 - 0.02*30) ~ 50.5
-# coef -0.05 gives contribution ~ -2.5; intercept calibrated for P(Y=1) ~ 0.3
-causal_parameters <- c(1.9, 0.1, 0.02, -0.5, -0.05)
+# Strong L→A: high L (good hemoglobin) → A = 0; low L → A = 1
+A_pars  <- c(10, -1, 0.1)
 
-pars <- list(
-  B   = list(beta = 0.1),
-  C   = list(beta = 1),
-  L   = list(beta = c(11, -0.05, -0.02), phi = 0.5),
-  A   = list(beta = c(30, -3, 0.1)),    # strong L->A
-  Y   = list(beta = causal_parameters),
-  cop = list(Y = list(L = list(k_tau = 0.1, par2 = 5)))  # negligible residual copula
+base_pars <- list(
+  B = list(beta = 0.1),
+  C = list(beta = 1),
+  L = list(beta = c(11, -0.05, -0.02), phi = 0.5),
+  A = list(beta = A_pars),
+  Y = list(beta = causal_parameters)
 )
 
-surv_model <- survivl_model(formulas = forms, family = fams,
-                            pars = pars, T = 5, dat = dat0, qtls = qtls)
-dat <- rmsm(n, surv_model)
+# ── Helper to build dat0 / qtls for a given n ────────────────────────────────
 
-# ── Estimators ─────────────────────────────────────────────────────────────────
+make_init <- function(n) {
+  qtls <- data.frame(matrix(runif(n * 4), ncol = 4))
+  colnames(qtls) <- c("B", "C", "L_0", "A_0")
+  qtls <- cbind(qtls, qtls[["A_0"]], qtls[["A_0"]])
+  colnames(qtls) <- c("B", "C", "L_0", "A_0", "A_1", "A_2")
 
-# IPW
-glm_A0     <- glm(A_0 ~ L_0,         family = binomial(), data = dat)
-glm_A3     <- glm(A_3 ~ L_3 + A_2,   family = binomial(), data = dat)
-glm_A4     <- glm(A_4 ~ L_4 + A_3,   family = binomial(), data = dat)
-glm_A0_num <- glm(A_0 ~ 1,           family = binomial(), data = dat)
-glm_A3_num <- glm(A_3 ~ A_0,         family = binomial(), data = dat)
-glm_A4_num <- glm(A_4 ~ A_0 + A_3,   family = binomial(), data = dat)
-
-ps_A0     <- predict(glm_A0,     type = "response")
-ps_A3     <- predict(glm_A3,     type = "response")
-ps_A4     <- predict(glm_A4,     type = "response")
-ps_A0_num <- predict(glm_A0_num, type = "response")
-ps_A3_num <- predict(glm_A3_num, type = "response")
-ps_A4_num <- predict(glm_A4_num, type = "response")
-
-w0 <- ifelse(dat$A_0 == 1, ps_A0, 1 - ps_A0)
-w3 <- ifelse(dat$A_3 == 1, ps_A3, 1 - ps_A3)
-w4 <- ifelse(dat$A_4 == 1, ps_A4, 1 - ps_A4)
-w0_num <- ifelse(dat$A_0 == 1, ps_A0_num, 1 - ps_A0_num)
-w3_num <- ifelse(dat$A_3 == 1, ps_A3_num, 1 - ps_A3_num)
-w4_num <- ifelse(dat$A_4 == 1, ps_A4_num, 1 - ps_A4_num)
-dat$iptw_weights <- w0_num * w3_num * w4_num / (w0 * w3 * w4)
-
-glm_Y_ipw     <- glm(Y ~ B + C + I(A_0 + A_1 + A_2 + A_3 + A_4),
-                     data = dat, weights = iptw_weights, family = binomial())
-glm_Y_outcome <- glm(Y ~ B + C + I(L_0 + L_1 + L_2 + L_3 + L_4) +
-                       I(A_0 + A_1 + A_2 + A_3 + A_4),
-                     data = dat, family = binomial())
-glm_Y_naive   <- glm(Y ~ B + C + I(A_0 + A_1 + A_2 + A_3 + A_4),
-                     data = dat, family = binomial())
-
-# ── Single-run results ─────────────────────────────────────────────────────────
-
-sumY_ipw     <- summary(glm_Y_ipw)
-sumY_outcome <- summary(glm_Y_outcome)
-sumY_naive   <- summary(glm_Y_naive)
-shared_nms   <- rownames(sumY_ipw$coefficients)
-
-cat("True A parameters (what IPW and naive target):\n")
-print(setNames(true_A_pars, shared_nms))
-
-cat("\n── Raw coefficients ──────────────────────────────────────────────────\n")
-coefs <- cbind(
-  truth   = true_A_pars,
-  ipw     = sumY_ipw$coefficients[, 1],
-  outcome = sumY_outcome$coefficients[shared_nms, 1],
-  naive   = sumY_naive$coefficients[, 1]
-)
-print(round(coefs, 4))
-
-cat("\n── SEs from truth (< 2 is good) ──────────────────────────────────────\n")
-ses <- cbind(
-  ipw     = abs(sumY_ipw$coefficients[, 1]     - true_A_pars) / sumY_ipw$coefficients[, 2],
-  outcome = abs(sumY_outcome$coefficients[shared_nms, 1] - true_A_pars) / sumY_outcome$coefficients[shared_nms, 2],
-  naive   = abs(sumY_naive$coefficients[, 1]   - true_A_pars) / sumY_naive$coefficients[, 2]
-)
-print(round(ses, 3))
-
-# ── Investigate confounding: does A predict L, and does L predict Y? ──────────
-
-cat("\n── Confounding check ─────────────────────────────────────────────────\n")
-cat("Correlation between sum(A) and mean(L):\n")
-sum_A  <- with(dat, A_0 + A_1 + A_2 + A_3 + A_4)
-mean_L <- with(dat, (L_0 + L_1 + L_2 + L_3 + L_4) / 5)
-cat(" cor(sum_A, mean_L) =", round(cor(sum_A, mean_L), 3), "\n")
-cat(" cor(mean_L, Y)     =", round(cor(mean_L, dat$Y), 3), "\n")
-cat(" cor(sum_A, Y)      =", round(cor(sum_A, dat$Y), 3), "\n")
-
-cat("\nTreatment prevalence by time point:\n")
-trt_prev <- colMeans(dat[, paste0("A_", 0:4)])
-print(round(trt_prev, 3))
-
-cat("\nMarginal P(Y=1) by sum_A:\n")
-breaks <- unique(quantile(sum_A, probs = 0:4/4))
-if (length(breaks) > 2) {
-  quartile_A <- cut(sum_A, breaks = breaks, include.lowest = TRUE)
-  print(round(tapply(dat$Y, quartile_A, mean), 3))
-} else {
-  print(round(tapply(dat$Y, sum_A, mean), 3))
+  B   <- qbinom(qtls[["B"]], 1, 0.1)
+  C   <- qunif(qtls[["C"]], 25, 35)
+  L_0 <- qnorm(qtls[["L_0"]], 11 - 0.05 * B - 0.02 * C, 0.5)
+  A_0 <- A_1 <- A_2 <- qbinom(qtls[["A_0"]], 1, 0.5)
+  dat0 <- cbind(B, C, L_0, A_0, A_1, A_2)
+  list(dat0 = dat0, qtls = qtls)
 }
 
-cat("\nIPW weight summary:\n")
-print(summary(dat$iptw_weights))
+# ── IPW + naive estimation, returns the treatment coefficient from each ──────
 
-# ── Monte Carlo: repeat over many seeds to check if naive is consistently good ─
-
-cat("\n── Monte Carlo bias check (50 replications, n=1000) ──────────────────\n")
-
-run_one <- function(seed) {
-  set.seed(seed)
-  n_mc <- 1e3
-
-  qtls_mc <- data.frame(matrix(runif(n_mc * 4), ncol = 4))
-  colnames(qtls_mc) <- c("B", "C", "L_0", "A_0")
-  qtls_mc <- cbind(qtls_mc, qtls_mc[["A_0"]], qtls_mc[["A_0"]])
-  colnames(qtls_mc) <- c("B", "C", "L_0", "A_0", "A_1", "A_2")
-
-  B_mc   <- qbinom(qtls_mc[["B"]], 1, 0.1)
-  C_mc   <- qunif(qtls_mc[["C"]], 25, 35)
-  L0_mc  <- qnorm(qtls_mc[["L_0"]], 11 - 0.05 * B_mc - 0.02 * C_mc, 0.5)
-  A0_mc  <- qbinom(qtls_mc[["A_0"]], 1, 0.5)
-  dat0_mc <- cbind(B = B_mc, C = C_mc, L_0 = L0_mc,
-                   A_0 = A0_mc, A_1 = A0_mc, A_2 = A0_mc)
-
-  pars_mc <- pars  # picks up updated pars from outer scope
-  sm <- suppressMessages(
-    survivl_model(formulas = forms, family = fams,
-                  pars = pars_mc, T = 5, dat = dat0_mc, qtls = qtls_mc)
-  )
-  d <- rmsm(n_mc, sm)
-
-  # IPW weights
+fit_estimators <- function(d) {
   a0d <- glm(A_0 ~ L_0,       family = binomial(), data = d)
   a3d <- glm(A_3 ~ L_3 + A_2, family = binomial(), data = d)
   a4d <- glm(A_4 ~ L_4 + A_3, family = binomial(), data = d)
@@ -227,27 +96,175 @@ run_one <- function(seed) {
   p4d <- predict(a4d, type = "response"); p0n <- predict(a0n, type = "response")
   p3n <- predict(a3n, type = "response"); p4n <- predict(a4n, type = "response")
 
-  w <- (ifelse(d$A_0==1, p0n, 1-p0n) * ifelse(d$A_3==1, p3n, 1-p3n) * ifelse(d$A_4==1, p4n, 1-p4n)) /
-       (ifelse(d$A_0==1, p0d, 1-p0d) * ifelse(d$A_3==1, p3d, 1-p3d) * ifelse(d$A_4==1, p4d, 1-p4d))
+  w <- (ifelse(d$A_0 == 1, p0n, 1 - p0n) *
+        ifelse(d$A_3 == 1, p3n, 1 - p3n) *
+        ifelse(d$A_4 == 1, p4n, 1 - p4n)) /
+       (ifelse(d$A_0 == 1, p0d, 1 - p0d) *
+        ifelse(d$A_3 == 1, p3d, 1 - p3d) *
+        ifelse(d$A_4 == 1, p4d, 1 - p4d))
   d$w <- w
 
-  fit_ipw   <- glm(Y ~ B + C + I(A_0+A_1+A_2+A_3+A_4), data=d, weights=w,  family=binomial())
-  fit_naive <- glm(Y ~ B + C + I(A_0+A_1+A_2+A_3+A_4), data=d, family=binomial())
+  fit_ipw   <- glm(Y ~ B + C + I(A_0 + A_1 + A_2 + A_3 + A_4),
+                   data = d, weights = w, family = binomial())
+  fit_naive <- glm(Y ~ B + C + I(A_0 + A_1 + A_2 + A_3 + A_4),
+                   data = d, family = binomial())
 
   trt_nm <- grep("^I\\(", names(coef(fit_ipw)), value = TRUE)
   c(ipw_trt   = unname(coef(fit_ipw)[trt_nm]),
-    naive_trt = unname(coef(fit_naive)[trt_nm]))
+    naive_trt = unname(coef(fit_naive)[trt_nm]),
+    weight_max = max(w),
+    weight_mean = mean(w))
 }
 
-mc_res <- t(sapply(1:50, run_one))
-truth_trt <- true_A_pars[4]  # -0.5
+# ── Scenario definitions ──────────────────────────────────────────────────────
+# Each scenario overrides (a) the copula formula entry forms[[5]], (b) the
+# copula family entry fams[[5]], and (c) the cop entry in pars.
 
-cat(sprintf("Treatment coef (truth = %.2f)\n", truth_trt))
-cat(sprintf("  IPW   — mean: %6.3f  bias: %6.3f  SD: %.3f\n",
-            mean(mc_res[,"ipw_trt"]),
-            mean(mc_res[,"ipw_trt"]) - truth_trt,
-            sd(mc_res[,"ipw_trt"])))
-cat(sprintf("  Naive — mean: %6.3f  bias: %6.3f  SD: %.3f\n",
-            mean(mc_res[,"naive_trt"]),
-            mean(mc_res[,"naive_trt"]) - truth_trt,
-            sd(mc_res[,"naive_trt"])))
+scenarios <- list(
+
+  weak_gaussian = list(
+    descr = "Weak Gaussian copula (k_tau = 0.1). Establishes baseline.",
+    forms5 = L ~ 1,
+    fam5   = 1,
+    cop    = list(Y = list(L = list(k_tau = 0.1, par2 = 5)))
+  ),
+
+  strong_gaussian = list(
+    descr = "Strong Gaussian copula (k_tau = 0.85). Heavy residual L–Y dep.",
+    forms5 = L ~ 1,
+    fam5   = 1,
+    cop    = list(Y = list(L = list(k_tau = 0.85, par2 = 5)))
+  ),
+
+  heavy_tail_t = list(
+    descr = "Strong t-copula (k_tau = 0.85, df = 2). Joint tail dependence.",
+    forms5 = L ~ 1,
+    fam5   = 2,
+    cop    = list(Y = list(L = list(k_tau = 0.85, df = 2, par2 = 2)))
+  ),
+
+  conditional_t = list(
+    # The copula parameter is a regression rho_i = 2*expit(beta0 + beta1*A_l1) - 1.
+    # At A_l1 = 0 we target rho ≈ 0.30, at A_l1 = 1 we target rho ≈ 0.90.
+    # So the L-Y dependence is much stronger after a treatment period — a
+    # genuinely conditional copula that the naive model can never reproduce.
+    descr = "Conditional t-copula: L–Y dep depends on past treatment A_l1.",
+    forms5 = list(Y = list(L ~ A_l1)),
+    fam5   = 2,
+    cop    = list(Y = list(L = list(
+      beta = c(rho_to_beta(0.30), rho_to_beta(0.90) - rho_to_beta(0.30)),
+      df   = 3,
+      par2 = 3
+    )))
+  ),
+
+  clayton = list(
+    descr = "Clayton copula (k_tau = 0.7). Lower-tail dependence only.",
+    forms5 = L ~ 1,
+    fam5   = 3,
+    cop    = list(Y = list(L = list(k_tau = 0.7, par2 = 5)))
+  ),
+
+  gumbel = list(
+    descr = "Gumbel copula (k_tau = 0.7). Upper-tail dependence only.",
+    forms5 = L ~ 1,
+    fam5   = 4,
+    cop    = list(Y = list(L = list(k_tau = 0.7, par2 = 5)))
+  )
+)
+
+# ── Build a survivl_model for a given scenario ────────────────────────────────
+
+build_model <- function(scn, dat0, qtls) {
+  f <- forms
+  f[[5]] <- scn$forms5
+  fa <- fams
+  fa[[5]] <- scn$fam5
+  p <- base_pars
+  p$cop <- scn$cop
+  survivl_model(formulas = f, family = fa, pars = p,
+                T = 5, dat = dat0, qtls = qtls)
+}
+
+# ── Single-shot diagnostic (large n) for the most interesting scenario ──────
+
+set.seed(42)
+n <- 1e4
+init <- make_init(n)
+
+cat("══════════════════════════════════════════════════════════════════════\n")
+cat("Single-run diagnostic on the conditional-t scenario, n =", n, "\n")
+cat("══════════════════════════════════════════════════════════════════════\n")
+
+sm  <- build_model(scenarios$conditional_t, init$dat0, init$qtls)
+dat <- rmsm(n, sm)
+
+est <- fit_estimators(dat)
+cat(sprintf("truth on sum_A coef = %.3f\n", causal_parameters[4]))
+cat(sprintf("  IPW   estimate     = %.3f  (bias %+0.3f)\n",
+            est["ipw_trt"],   est["ipw_trt"]   - causal_parameters[4]))
+cat(sprintf("  Naive estimate     = %.3f  (bias %+0.3f)\n",
+            est["naive_trt"], est["naive_trt"] - causal_parameters[4]))
+cat(sprintf("  max IPW weight = %.2f, mean weight = %.3f\n",
+            est["weight_max"], est["weight_mean"]))
+
+sum_A  <- with(dat, A_0 + A_1 + A_2 + A_3 + A_4)
+mean_L <- with(dat, (L_0 + L_1 + L_2 + L_3 + L_4) / 5)
+cat(sprintf("\ncor(sum_A, mean_L) = %.3f\n",  cor(sum_A, mean_L)))
+cat(sprintf("cor(mean_L, Y)     = %.3f\n",    cor(mean_L, dat$Y)))
+cat(sprintf("cor(sum_A, Y)      = %.3f\n",    cor(sum_A, dat$Y)))
+
+# ── Monte Carlo sweep across scenarios ────────────────────────────────────────
+
+cat("\n══════════════════════════════════════════════════════════════════════\n")
+cat("Monte Carlo sweep: 50 reps, n = 1000, across copula parametrizations\n")
+cat("══════════════════════════════════════════════════════════════════════\n")
+
+run_one <- function(seed, scn) {
+  set.seed(seed)
+  init_mc <- make_init(1000)
+  sm <- suppressMessages(build_model(scn, init_mc$dat0, init_mc$qtls))
+  d  <- rmsm(1000, sm)
+  fit_estimators(d)
+}
+
+results <- lapply(names(scenarios), function(nm) {
+  scn <- scenarios[[nm]]
+  cat(sprintf("\n--- %s ---\n%s\n", nm, scn$descr))
+  mc <- t(sapply(1:50, function(s) {
+    tryCatch(run_one(s, scn),
+             error = function(e) c(ipw_trt = NA, naive_trt = NA,
+                                   weight_max = NA, weight_mean = NA))
+  }))
+  truth <- causal_parameters[4]
+  cat(sprintf("  IPW   mean = %6.3f   bias = %+0.3f   SD = %.3f\n",
+              mean(mc[, "ipw_trt"],   na.rm = TRUE),
+              mean(mc[, "ipw_trt"],   na.rm = TRUE) - truth,
+              sd(mc[, "ipw_trt"],     na.rm = TRUE)))
+  cat(sprintf("  Naive mean = %6.3f   bias = %+0.3f   SD = %.3f\n",
+              mean(mc[, "naive_trt"], na.rm = TRUE),
+              mean(mc[, "naive_trt"], na.rm = TRUE) - truth,
+              sd(mc[, "naive_trt"],   na.rm = TRUE)))
+  cat(sprintf("  weight: mean(max) = %.1f, mean(mean) = %.2f\n",
+              mean(mc[, "weight_max"],  na.rm = TRUE),
+              mean(mc[, "weight_mean"], na.rm = TRUE)))
+  mc
+})
+names(results) <- names(scenarios)
+
+# ── Summary table ─────────────────────────────────────────────────────────────
+
+cat("\n══════════════════════════════════════════════════════════════════════\n")
+cat("Summary: bias relative to truth = ", causal_parameters[4], "\n")
+cat("══════════════════════════════════════════════════════════════════════\n")
+summary_tbl <- t(sapply(results, function(mc) {
+  c(ipw_bias   = mean(mc[, "ipw_trt"],   na.rm = TRUE) - causal_parameters[4],
+    naive_bias = mean(mc[, "naive_trt"], na.rm = TRUE) - causal_parameters[4],
+    ipw_sd     = sd(mc[, "ipw_trt"],     na.rm = TRUE),
+    naive_sd   = sd(mc[, "naive_trt"],   na.rm = TRUE),
+    bias_gap   = abs(mean(mc[, "naive_trt"], na.rm = TRUE) - causal_parameters[4]) -
+                 abs(mean(mc[, "ipw_trt"],   na.rm = TRUE) - causal_parameters[4]))
+}))
+print(round(summary_tbl, 3))
+cat("\nThe `bias_gap` column = |naive bias| - |IPW bias|. Bigger = better\n")
+cat("evidence that IPW separates from naive under this parametrization.\n")

--- a/investigate_naive.R
+++ b/investigate_naive.R
@@ -331,23 +331,24 @@ scenarios <- list(
   # ─────────────────────────────────────────────────────────────────────────
 
   simpson_flip = list(
-    # Small-variance flip. sd(Y) = 1 so coefficients sit on a familiar scale.
-    # The per-dose delta between IPW and naive is ~0.05 (constrained by
-    # rho·sd_Y / sd_sumA), but it's enough to flip the sign of a -0.05 truth.
-    # Over the 8-dose course the cumulative delta is ~0.4 sd(Y).
-    descr = "★ SIMPSON FLIP (small sd_Y=1): truth -0.05, naive ≈ +0.005, IPW ≈ -0.05.",
+    # sd(Y) = 20 keeps Y on a natural continuous scale (think a clinical score
+    # like change in haemoglobin × 10) while still giving a big per-dose delta.
+    # Truth says each dose lowers Y by 0.8 (cumulative -6.4 over 8 doses).
+    # Naive sign-flips to ≈ +0.48 (cumulative +3.8). IPW recovers ≈ -0.58
+    # (modestly attenuated but right direction).
+    descr = "★ SIMPSON FLIP (sd_Y=20): truth -0.8, naive ≈ +0.48, IPW ≈ -0.58.",
     T      = 8,
     forms5 = list(Y = list(L ~ A_l1)),
     fam5   = 2,
     Y_fam  = 1,
-    Y_phi  = 1,                              # sd_Y = 1
+    Y_phi  = 400,                            # sd_Y = 20
     wide_L = TRUE,
     L_pars = c(0, 0, 0),
     L_phi  = 9,                              # sd_L = 3
-    A_pars = c(0, 1.5, 0.5),                 # reversed L→A, mild persistence
-    Y_pars = c(0, 0, 0, -0.05),              # truth -0.05 per dose
+    A_pars = c(0, 1.2, 0.5),                 # reversed L→A, mild persistence
+    Y_pars = c(0, 0, 0, -0.8),               # truth -0.8 per dose
     cop    = list(Y = list(L = list(
-      beta = c(rho_to_beta(0.00), rho_to_beta(0.99) - rho_to_beta(0.00)),
+      beta = c(rho_to_beta(0.30), rho_to_beta(0.99) - rho_to_beta(0.30)),
       df   = 3,
       par2 = 3
     )))
@@ -375,19 +376,19 @@ scenarios <- list(
   ),
 
   simpson_null = list(
-    descr = "★ SIMPSON null (sd_Y=1): truth = 0, naive ≈ +0.06.",
+    descr = "★ SIMPSON null (sd_Y=20): truth = 0, naive ≈ +1.0 (fabricated harm).",
     T      = 8,
     forms5 = list(Y = list(L ~ A_l1)),
     fam5   = 2,
     Y_fam  = 1,
-    Y_phi  = 1,
+    Y_phi  = 400,
     wide_L = TRUE,
     L_pars = c(0, 0, 0),
     L_phi  = 9,
-    A_pars = c(0, 1.5, 0.5),
+    A_pars = c(0, 1.2, 0.5),
     Y_pars = c(0, 0, 0, 0),
     cop    = list(Y = list(L = list(
-      beta = c(rho_to_beta(0.00), rho_to_beta(0.99) - rho_to_beta(0.00)),
+      beta = c(rho_to_beta(0.30), rho_to_beta(0.99) - rho_to_beta(0.30)),
       df   = 3,
       par2 = 3
     )))

--- a/vignettes/Simpson-Flip.Rmd
+++ b/vignettes/Simpson-Flip.Rmd
@@ -1,0 +1,173 @@
+---
+title: "Simpson's Paradox: When IPW and Naive Disagree on the Sign"
+author: "Chase Mathis"
+date: "`r Sys.Date()`"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Simpson-Flip}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE, message = FALSE, warning = FALSE)
+options(digits = 4)
+```
+
+# Goal
+
+The `Longitudinal-Single-Outcome` vignette shows IPW and a naive outcome
+regression giving roughly the same answer — it is hard to see which is
+right just by looking at the numbers. This vignette goes the other way: we
+build a longitudinal MSM whose **naive estimator gets the sign of the
+treatment effect wrong**, while IPW correctly recovers the truth on average.
+Same story as classical Simpson's paradox in cross-sectional data —
+adjustment is not optional.
+
+# The recipe
+
+Three design choices make naive and IPW diverge dramatically.
+
+1. **Drop the time-varying confounder $L$ out of the structural model.** All
+   of $L \to Y$ flows through the copula, so the strength of the copula
+   directly controls how much unmeasured confounding the naive model sees.
+2. **Reverse $L \to A$ direction** (high $L$ → treated) and pair it with a
+   **positive** $L$–$Y$ copula. Both bias channels now push naive in the
+   *opposite* direction from the structural causal effect.
+3. **Use a conditional copula**: the latent correlation
+   $\rho_t = 2 \cdot \text{expit}(\beta_0 + \beta_1 A_{t-1}) - 1$ swings
+   from $\approx 0.30$ when last period was untreated to $\approx 0.95$
+   when it was. The naive marginal model cannot match this treatment-
+   modified dependence.
+
+We raise $T$ from 5 to 8 so that more periods are model-generated and
+confounded (`dat0` fixes $A_0 = A_1 = A_2$, so only $A_3 \ldots A_{T-1}$ are
+freshly drawn from the propensity model). The outcome $Y$ is Gaussian with
+$\text{sd}(Y) = 20$.
+
+```{r load}
+library(survivl)
+
+rho_to_beta <- function(rho) log(((rho + 1) / 2) / (1 - (rho + 1) / 2))
+```
+
+# DGP
+
+```{r dgp-setup}
+n     <- 5000
+T_use <- 8
+
+A_vars    <- paste0("A_", 0:(T_use - 1))
+sumA_form <- as.formula(paste("Y ~ B + C + I(",
+                              paste(A_vars, collapse = "+"), ")"))
+
+make_init <- function(n) {
+  qtls <- data.frame(matrix(runif(n * 4), ncol = 4))
+  colnames(qtls) <- c("B", "C", "L_0", "A_0")
+  qtls <- cbind(qtls, A_1 = qtls$A_0, A_2 = qtls$A_0)
+  B   <- qbinom(qtls$B, 1, 0.1)
+  C   <- qunif(qtls$C, 25, 35)
+  L_0 <- qnorm(qtls$L_0, 0, 3)              # wide L, sd = 3
+  A_0 <- A_1 <- A_2 <- qbinom(qtls$A_0, 1, 0.5)
+  list(dat0 = cbind(B, C, L_0, A_0, A_1, A_2), qtls = qtls)
+}
+
+forms <- list(list(B ~ 1, C ~ 1),
+              L ~ B + C,
+              A ~ L_l0 + A_l1,                       # high L → treated
+              sumA_form,
+              list(Y = list(L ~ A_l1)))              # conditional copula
+fams  <- list(list(5, 4), 1, 5, 1, 2)                # Y Gaussian, copula t
+
+pars <- list(
+  B = list(beta = 0),
+  C = list(beta = 0),
+  L = list(beta = c(0, 0, 0), phi = 9),
+  A = list(beta = c(0, 0.8, 0.3)),                   # reversed L→A + persistence
+  Y = list(beta = c(0, 0, 0, -0.8),                  # TRUTH: -0.8 per dose
+           phi  = 400),                              # sd(Y) = 20
+  cop = list(Y = list(L = list(
+    beta = c(rho_to_beta(0.30), rho_to_beta(0.95) - rho_to_beta(0.30)),
+    df   = 3,
+    par2 = 3
+  )))
+)
+```
+
+# Naive and IPW in one helper
+
+```{r estimators}
+fit_one <- function(seed) {
+  set.seed(seed)
+  init <- make_init(n)
+  sm   <- survivl_model(formulas = forms, family = fams, pars = pars,
+                        T = T_use, dat = init$dat0, qtls = init$qtls)
+  d    <- rmsm(n, sm)
+
+  # IPW weights from the freshly-drawn periods t = 3, ..., T-1
+  log_w <- rep(0, n)
+  for (t in 3:(T_use - 1)) {
+    a  <- paste0("A_", t); l <- paste0("L_", t); ap <- paste0("A_", t - 1)
+    denom <- glm(as.formula(paste(a, "~", l, "+", ap)),
+                 family = binomial(), data = d)
+    numer <- glm(as.formula(paste(a, "~", ap)),
+                 family = binomial(), data = d)
+    pd <- predict(denom, type = "response")
+    pn <- predict(numer, type = "response")
+    aa <- d[[a]]
+    log_w <- log_w + log(ifelse(aa == 1, pn, 1 - pn)) -
+                     log(ifelse(aa == 1, pd, 1 - pd))
+  }
+  d$w <- exp(log_w)
+
+  fit_naive <- lm(sumA_form, data = d)
+  fit_ipw   <- lm(sumA_form, data = d, weights = w)
+  trt       <- length(coef(fit_naive))
+  c(naive = unname(coef(fit_naive)[trt]),
+    ipw   = unname(coef(fit_ipw)[trt]))
+}
+```
+
+# Monte Carlo
+
+Per-replication IPW carries substantial variance under strong
+$L \to A$ confounding because the propensity model becomes nearly
+deterministic at the tails. We average over 20 replications:
+
+```{r mc}
+mc <- t(sapply(1:20, fit_one))
+results <- data.frame(
+  estimator    = c("Truth", "IPW", "Naive"),
+  per_dose     = c(-0.8, mean(mc[, "ipw"]), mean(mc[, "naive"])),
+  per_dose_sd  = c(NA,   sd(mc[, "ipw"]),   sd(mc[, "naive"])),
+  cumulative_8 = c(-0.8, mean(mc[, "ipw"]), mean(mc[, "naive"])) * T_use
+)
+knitr::kable(results, digits = 3,
+             caption = "Per-dose coefficient and total effect over 8 doses")
+```
+
+The story:
+
+- **Truth:** each dose of treatment lowers $Y$ by 0.8 units; over 8 doses
+  the cumulative effect is $-6.4$ ($\approx 0.3$ standard deviations of
+  $Y$).
+- **IPW** recovers a clearly negative effect, close to truth on average.
+- **Naive** estimates a *positive* per-dose effect — it claims treatment
+  *raises* $Y$. The signs of the two estimators are opposite.
+
+# Why does this happen?
+
+The copula gives high $L$ a strong positive association with $Y$ that is
+not captured anywhere in the structural model. Because high $L$ also makes
+treatment more likely (reversed $L \to A$), patients who get treated are
+exactly those who would have had high $Y$ anyway. The naive regression
+sees: people on treatment have high $Y$, so treatment must raise $Y$. IPW
+corrects for the imbalance in $L$ between treated and untreated periods
+and uncovers the true negative structural effect.
+
+# Sanity check: null truth
+
+If we set `pars$Y$beta[4] <- 0` and rerun, the naive estimator still
+fabricates a positive harmful effect (about $+0.4$ per dose), while IPW
+sits near zero. The naive bias is pure confounding, not a fact about
+the treatment.


### PR DESCRIPTION
## Summary

Investigates the original Longitudinal-Single-Outcome vignette's question of "how do we make naive and IPW visibly disagree" by sweeping copula parametrizations, then lands on a Simpson's-paradox sign-flip recipe and packages it as a new vignette.

### Bug fix

`survivl` was forwarding `list(k_tau = ...)` to `causl::rescale_cop`, but causl only reads `tau` (or `beta`). Every `k_tau`-form copula spec was silently failing with `Neither 'beta' nor 'tau' specified`, so the existing Longitudinal-Single-Outcome vignette has been running with the L–Y copula effectively *off*. Renamed the field in two places:

- `R/sim_variable.R`
- `R/sim_inversion_longitudinal.R`

### New vignette: `Simpson-Flip.Rmd`

A longitudinal MSM whose naive estimator gets the *sign* of the treatment effect wrong while IPW recovers the truth. Recipe:

- `T = 8`, wide L (sd = 3), Gaussian Y with sd = 20
- Reversed L→A (high L → treated) with mild persistence
- Conditional t-copula whose ρ swings 0.30 → 0.95 with past treatment
- Structural effect −0.8 per dose; L dropped from the structural Y formula so all L→Y flows through the copula

Headline MC numbers (20 reps, n = 5000):

| estimator | per dose | over 8 doses |
|---|---|---|
| truth | −0.80 | −6.4 |
| IPW   | −1.05 | −8.4 |
| naive | **+0.58** | **+4.6** |

### `investigate_naive.R` rewrite

Sweep harness covering 14 copula parametrizations (Gaussian, t, Clayton, conditional, sharp/wide variants) with a per-scenario summary table reporting `truth`, `ipw_est`, `naive_est`, `bias_gap`, `cum_delta`, `sign_flip`. Useful as a development scratchpad and as backing evidence for the recipe used in the vignette.

## Test plan

- [x] `R CMD INSTALL .` succeeds
- [ ] `Rscript investigate_naive.R` runs and produces the summary table; `simpson_flip` row has `sign_flip = 1`
- [ ] `vignettes/Simpson-Flip.Rmd` knits without errors
- [ ] Existing `Longitudinal-Single-Outcome.Rmd` still knits (now actually applies its copula thanks to the k_tau→tau fix)

https://claude.ai/code/session_01UCKjzGUELo6pKfVyYVJMnM

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCKjzGUELo6pKfVyYVJMnM)_