### PR TITLE
Fix k_tau copula forwarding to match causl API

### DIFF
--- a/R/sim_inversion_longitudinal.R
+++ b/R/sim_inversion_longitudinal.R
@@ -62,7 +62,7 @@ sim_inversion_longitudinal <- function(out, surv_model) {
       cop_fams[[l, j]] <- family[[5]][[1]][[l]]
       cop_forms[[l, j]] <- mod_inputs$formulas[[4]][[1]][[l]][[idx]]
       cop_pars[[l, j]] <- if (!is.null(mod_inputs$pars$cop[[1]][[l]]$k_tau)) {
-        list(tau = mod_inputs$pars$cop[[1]][[l]]$k_tau, df = mod_inputs$pars$cop[[1]][[l]]$df)
+        list(k_tau = mod_inputs$pars$cop[[1]][[l]]$k_tau, df = mod_inputs$pars$cop[[1]][[l]]$df)
       } else {
         list(beta = mod_inputs$pars$cop[[1]][[l]]$beta[[idx]], df = mod_inputs$pars$cop[[1]][[l]]$df)
       }

--- a/R/sim_variable.R
+++ b/R/sim_variable.R
@@ -46,7 +46,7 @@ sim_variable <- function(n, formulas, family, pars, link,
       cop_fams[[l, j]] <- family[[2]][l]
       cop_forms[[l, j]] <- formulas[[2]][[l]][[idx]]
       cop_pars[[l, j]] <- if (!is.null(pars$cop[[1]][[l]]$k_tau)) {
-        list(tau = pars$cop[[1]][[l]]$k_tau, df = pars$cop[[1]][[l]]$df)
+        list(k_tau = pars$cop[[1]][[l]]$k_tau, df = pars$cop[[1]][[l]]$df)
       } else {
         list(beta = pars$cop[[1]][[l]]$beta[[idx]], df = pars$cop[[1]][[l]]$df)
       }


### PR DESCRIPTION
## Problem

Specifying a copula association via `k_tau` (instead of `beta`) currently fails:

```
Error: Neither 'beta' nor 'k_tau' specified
```

`causl`'s `rescale_cop()` accepts the parameter named `beta` or `k_tau` (causl renamed `tau` → `k_tau`), but `survivl` was forwarding it under the stale name `tau`:

- `R/sim_inversion_longitudinal.R:65`
- `R/sim_variable.R:49`

So the name never matched and any `k_tau` model errored. (The merged dose-escalation PR kept the `tau` name; this aligns it with the current `causl`.)

## Fix

Rename `tau` → `k_tau` at both call sites. The `beta` parameterization was unaffected.

## Verification

- A longitudinal model with `cop = list(Y = list(Z = list(k_tau = 0.4)))` now samples (empirical Kendall τ ≈ 0.34 after weaving across time steps).
- Full test suite: **0 failures, 32 pass** (2 pre-existing `glm.fit` warnings in the Seaman-Keogh test, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)